### PR TITLE
Fix stats bug, admins can add other admins

### DIFF
--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -37,7 +37,6 @@ public class AdminServlet extends HttpServlet {
 
   /** Store class that gives access to Users. */
   private UserStore userStore;
-
   private ConversationStore convoStore;
   private MessageStore messageStore;
 
@@ -49,7 +48,6 @@ public class AdminServlet extends HttpServlet {
   public void init() throws ServletException {
 	super.init();
 	setUserStore(UserStore.getInstance());
-
 	setConversationStore(ConversationStore.getInstance());
 	setMessageStore(MessageStore.getInstance());
   }
@@ -79,6 +77,44 @@ public class AdminServlet extends HttpServlet {
 	request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
   }
 
+	public void addAdmin(HttpServletRequest request, HttpServletResponse response)
+		throws IOException, ServletException {
+
+			String username = request.getParameter("username");
+			System.out.println(username);
+			if (!username.matches("[\\w*\\s*]*")) {
+	  			request.setAttribute("error", "Please enter only letters, numbers, and spaces.");
+	  			request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
+	  			return;
+	  		}
+
+		    if (userStore.isUserRegistered(username)) {
+		      	request.setAttribute("error", "That username is already taken.");
+		      	request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
+		      	return;
+		    }
+
+			userStore.addAdmin(username);
+			request.setAttribute("success", "Admin successfully added");
+		    request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
+	}
+
+	public void refreshStats(HttpServletRequest request, HttpServletResponse response)
+		throws IOException, ServletException {
+			List<User> totalUsers = userStore.getUsers();
+			List<Conversation> totalConvos = convoStore.getAllConversations();
+			List<Message> totalMessages = messageStore.getAllMessages();
+
+			int numTotalUsers = totalUsers.size();
+			int numTotalConvos = totalConvos.size();
+			int numTotalMessages = totalMessages.size();
+
+			request.getSession().setAttribute("numUsers", numTotalUsers);
+			request.getSession().setAttribute("numConvos", numTotalConvos);
+			request.getSession().setAttribute("numMessages", numTotalMessages);
+
+		}
+
   /**
    * This function fires when a user submits the refresh stats form (clicks the refresh stats button). It gets the totalUsers,
    TotalConvos, and totalMessages each time to provide a hot-reload of what is happening.
@@ -87,48 +123,16 @@ public class AdminServlet extends HttpServlet {
 	public void doPost(HttpServletRequest request, HttpServletResponse response)
 		throws IOException, ServletException {
 		// 	A method allowing the admin to refresh stats on the fly!
+			refreshStats(request, response);
+			System.out.println(request.getParameter("username"));
+			if(request.getParameter("username") != null){
+				addAdmin(request, response);
+			}
+			else{
+				response.sendRedirect("/admin");
+			}
 
-		List<User> totalUsers = userStore.getUsers();
-		List<Conversation> totalConvos = convoStore.getAllConversations();
-		List<Message> totalMessages = messageStore.getAllMessages();
-
-		int numTotalUsers = totalUsers.size();
-		int numTotalConvos = totalConvos.size();
-		int numTotalMessages = totalMessages.size();
-
-		request.getSession().setAttribute("numUsers", numTotalUsers);
-		request.getSession().setAttribute("numConvos", numTotalConvos);
-		request.getSession().setAttribute("numMessages", numTotalMessages);
-		// request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request,response);
-		response.sendRedirect("/admin");
 	}
-
-	public void addAdmin(HttpServletRequest request, HttpServletResponse response)
-		throws IOException, ServletException {
-			String username = request.getParameter("username");
-
-			if (!username.matches("[\\w*\\s*]*")) {
-      			request.setAttribute("error", "Please enter only letters, numbers, and spaces.");
-      			request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
-      		}
-	}
-		
-	// }
-	// if(admin){
-	//   	request.getSession().setAttribute("user", username);
-	//   	request.getSession().setAttribute("admin", username);
-	//   	System.out.println("userstore is comin");
-	//   	System.out.println(userStore);
-	//   	System.out.println("did userstore work??? hmm");
-	//   	response.sendRedirect("/admin");
-	// }
-	// else{
-	//   	request.getSession().setAttribute("user", (username));
-	// 	response.sendRedirect("/conversations");
-	// }
-
-	// Begin the data statistics portion
-
 
 }
 

--- a/src/main/java/codeu/controller/LoginServlet.java
+++ b/src/main/java/codeu/controller/LoginServlet.java
@@ -29,7 +29,6 @@ public class LoginServlet extends HttpServlet {
 
 	/** Store class that gives access to Users. */
 	private UserStore userStore;
-
 	/**
 	 * Set up state for handling login-related requests. This method is only called when running in a
 	 * server, not when running in a test.
@@ -88,15 +87,10 @@ public class LoginServlet extends HttpServlet {
 		boolean admin = userStore.isUserAdmin(username);
 
 		if(admin){
-			int totalUsers = userStore.getUsers().size();
-			
+
 			request.getSession().setAttribute("user", username);
 			request.getSession().setAttribute("admin", username);
-			request.getSession().setAttribute("numUsers", totalUsers);
-			// request.getSession().setAttribute("numConvos", totalConvos);
-			// request.getSession().setAttribute("numMessages", totalMessages);
-			// request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
-			// request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
+
 			response.sendRedirect("/admin");
 		}
 		else{

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -136,7 +136,7 @@ public class UserStore {
     return false;
   }
 
-  /** Return true if the given username is known to be an admin. */
+  /* Return true if the given username is known to be an admin. */
   public boolean isUserAdmin(String username){
     for(String name : adminUsernames){
       if(name.equals(username)) {
@@ -146,7 +146,14 @@ public class UserStore {
     return false;
   }
 
+/* Adds another admin */
+  public void addAdmin(String username){
+    adminUsernames.add(username);
+  }
 
+  public List getAdmins(){
+    return adminUsernames;
+  }
   /**
    * Sets the List of Users stored by this UserStore. This should only be called once, when the data
    * is loaded from Datastore.

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -20,7 +20,6 @@
 	<link rel="stylesheet" href="/css/main.css">
 </head>
 <body>
-
 	<nav> <%-- the menu navbar --%>
 		<a id="navTitle" href="/">Trill</a>
 		<a href="/conversations">Conversations</a>
@@ -40,8 +39,6 @@
 	<div id="container">
 		<div
 			style="width:75%; margin-left:auto; margin-right:auto; margin-top: 50px;">
-
-			<h1>CodeU Summer 2018</h1>
 			<h2>Welcome to our glorious ADMIN PAGE!</h2>
 			<h3>Powered by JavaChips</h3>
 		</div>
@@ -50,18 +47,38 @@
 			style="width:85%; margin-left:auto; margin-right:auto; margin-top: 50px;">
 			<h2>Checkout these wonderful site statistics!</h2>
 			<form action="/admin" method="POST">
-				<button type="refresh">Refesh Stats</button>
+				<button type="refresh">Get Stats</button>
 			</form>
 			<ul>
-				<li><a>Total Users: <%= request.getSession().getAttribute("numUsers") %></a></li>
-				<li><a>Total Conversations: <%= request.getSession().getAttribute("numConvos") %></a></li>
-				<li><a>Total Messages: <%= request.getSession().getAttribute("numMessages") %></a></li>
+				<% if(request.getSession().getAttribute("numUsers")!= null){ %>
+					<li><a>Total Users: <%= request.getSession().getAttribute("numUsers") %></a></li>
+				<% } %>
+
+				<% if(request.getSession().getAttribute("numConvos")!= null){ %>
+					<li><a>Total Conversations: <%= request.getSession().getAttribute("numConvos") %></a></li>
+				<% } %>
+
+				<% if(request.getSession().getAttribute("numMessages")!= null){ %>
+					<li><a>Total Messages: <%= request.getSession().getAttribute("numUsers") %></a></li>
+				<% } %>
 			</ul>
+		</div>
+		<div id="graphs">
 			<h3>A graph displaying new users as a function of time in months goes here!</h3>
 			<h3>A graph displaying new messages as a function of time in hours goes here!</h3>
+		</div>
+		<div id="addAdmins">
+			<h2>Feeling lonely?</h2>
+			<h3>Add more admins:</h3>
 
-			<h3>Add admins:</h3>
-		    <form action="/admin" method="addAdmin">
+		    <% if(request.getAttribute("error") != null){ %>
+		        <h2 style="color:red"><%= request.getAttribute("error") %></h2>
+		    <% } %>
+		    <% if(request.getAttribute("success") != null){ %>
+		        <h2 style="color:green"><%= request.getAttribute("success") %></h2>
+		        <h3 style="color:green">Now use that distinct username to register as an Administrator!</h3>
+		    <% } %>
+		    <form action="/admin" method="POST">
 		      <label for="username">Username: </label>
 		      <br/>
 		      <input type="text" name="username" id="username">
@@ -70,7 +87,6 @@
 		    </form>
 		</div>
 	</div>
-
 
 </body>
 </html>

--- a/src/test/java/codeu/controller/LoginServletTest.java
+++ b/src/test/java/codeu/controller/LoginServletTest.java
@@ -14,12 +14,12 @@
 
 package codeu.controller;
 
-import codeu.model.data.User;
-import codeu.model.store.basic.UserStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.UUID;
 
+import codeu.model.data.User;
+import codeu.model.store.basic.UserStore;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -110,13 +110,13 @@ public class LoginServletTest {
     Mockito.when(mockRequest.getParameter("password")).thenReturn("test password");
 
     UserStore mockUserStore = Mockito.mock(UserStore.class);
+
     Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(true);
 
     Mockito.when(mockUserStore.isUserAdmin("test username")).thenReturn(true);
 
     Mockito.when(mockUserStore.getUser("test username")).thenReturn(user);
     loginServlet.setUserStore(mockUserStore);
-
     HttpSession mockSession = Mockito.mock(HttpSession.class);
     Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
 


### PR DESCRIPTION
Fixed Admin stats bug

Added admins the ability to add other admins by creating a specific username that's whitelisted to have admin privileges. The person must then register for an account with that specific username.